### PR TITLE
Adapted REG2 PIPICO Targets

### DIFF
--- a/platformio.custom.ini
+++ b/platformio.custom.ini
@@ -90,14 +90,23 @@ build_flags =
   ${RP2040_EXCHANGE_2MB.build_flags}
   -D OKNXHW_PIPICO_BCU_CONNECTOR
 
-[env:release_OKNXHW_REG2_PIPICO_V1_BASE]
-extends = RP2040_releases, RP2040_custom, RP2040_EXCHANGE_16MB, RP2040_UPLOAD_USB
+[env:release_OKNXHW_REG2_PIPICO_V1]
+extends = RP2040_releases, RP2040_custom, RP2040_EXCHANGE_2MB, RP2040_UPLOAD_USB
 build_flags =
   ${RP2040_releases.build_flags}
   ${RP2040_custom.build_flags}
   ${custom_releases.build_flags}
-  ${RP2040_EXCHANGE_16MB.build_flags}
-  -D OKNXHW_REG2_PIPICO_V1_BASE
+  ${RP2040_EXCHANGE_2MB.build_flags}
+  -D OKNXHW_REG2_PIPICO_V1
+
+[env:release_OKNXHW_REG2_PIPICO_W_V1]
+extends = RP2040_releases, RP2040_custom, RP2040_EXCHANGE_2MB, RP2040_UPLOAD_USB
+build_flags =
+  ${RP2040_releases.build_flags}
+  ${RP2040_custom.build_flags}
+  ${custom_releases.build_flags}
+  ${RP2040_EXCHANGE_2MB.build_flags}
+  -D OKNXHW_REG2_PIPICO_W_V1
 
 [env:release_OKNXHW_REG1_APP_SEN_MULTI]
 extends = RP2040_releases, RP2040_custom, RP2040_EXCHANGE_16MB, RP2040_UPLOAD_USB

--- a/scripts/Build-Release.ps1
+++ b/scripts/Build-Release.ps1
@@ -46,8 +46,12 @@ if (!$?) { exit 1 }
 ../OGM-Common/scripts/setup/reusable/Build-Step.ps1 release_OKNXHW_REG1_BASE_V1 OpenKNX-REG1-SEN-Multi uf2
 if (!$?) { exit 1 }
 
-../OGM-Common/scripts/setup/reusable/Build-Step.ps1 release_OKNXHW_REG2_PIPICO_V1_BASE OKNXHW_REG2_PIPICO_V1_BASE uf2
+../OGM-Common/scripts/setup/reusable/Build-Step.ps1 release_OKNXHW_REG2_PIPICO_V1 OKNXHW_REG2_PIPICO_V1 uf2
 if (!$?) { exit 1 }
+
+../OGM-Common/scripts/setup/reusable/Build-Step.ps1 release_OKNXHW_REG2_PIPICO_W_V1 OKNXHW_REG2_PIPICO_W_V1 uf2
+if (!$?) { exit 1 }
+
 
 ../OGM-Common/scripts/setup/reusable/Build-Step.ps1 release_SMARTMF_1TE_BE3 SmartMF-1TE-BE3 uf2
 if (!$?) { exit 1 }


### PR DESCRIPTION
- Changed OKNXHW_REG2_PIPICO_V1_BASE to release_OKNXHW_REG2_PIPICO_V1
- Add release_OKNXHW_REG2_PIPICO_W_V1
- Using  RP2040_EXCHANGE_2MB instead RP2040_EXCHANGE_16MB